### PR TITLE
Shifts node versions to 14.x, 15.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
14.x is the new LTS, and 15.x is the latest; let's shift the actions so we test on those, instead of 12!